### PR TITLE
Optionally limit the loaded language models

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php" colors="true">
-<testsuites>
-  <testsuite name="LanguageDetector Test Suite">
-    <directory>./tests/LanguageDetector/</directory>
-  </testsuite>
-</testsuites>
-
-<logging>
-    <log type="coverage-clover" target="build/logs/clover.xml"/>
-</logging>
-
-<filter>
-  <whitelist processUncoveredFilesFromWhitelist="true">
-    <directory suffix=".php">src</directory>
-  </whitelist>
-</filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="LanguageDetector Test Suite">
+      <directory>./tests/LanguageDetector/</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/src/LanguageDetector/LanguageDetector.php
+++ b/src/LanguageDetector/LanguageDetector.php
@@ -43,14 +43,17 @@ class LanguageDetector
      * Configure all subset languages
      * 
      * @param  string $dir A directory where subsets are.
+     * @param  array $languages Language codes to load models for. By default, all languages are loaded.
      */
-    public function __construct($dir = null)
+    public function __construct($dir = null, $languages = null)
     {
         $datadir = null === $dir
             ? __DIR__ . '/subsets' : rtrim($dir, '/');
 
         foreach (glob($datadir . '/*') as $file) {
-            $this->languages[basename($file)] = new Language($file);
+            if (! $languages || in_array(basename($file), $languages)) {
+                $this->languages[basename($file)] = new Language($file);
+            }
         }
     }
 

--- a/tests/LanguageDetector/LanguageDetectionTest.php
+++ b/tests/LanguageDetector/LanguageDetectionTest.php
@@ -157,4 +157,32 @@ class LanguageDetectionTest extends TestCase
             $detector->getText()
         );
     }
+
+    /**
+     * __construct() method
+     */
+    public function testLanguageRestriction()
+    {
+        $text = 'My tailor is rich and Alison is in the kitchen with Bob.';
+
+        $detector = new LanguageDetector(null, ['da', 'no', 'sv']);
+
+        $detector->evaluate($text);
+
+        // After evaluation
+        $this->assertNotEquals(
+            'en',
+            $detector->getLanguage()
+        );
+
+        $detector = new LanguageDetector(null, ['da', 'no', 'sv', 'en']);
+
+        $detector->evaluate($text);
+
+        // After evaluation
+        $this->assertEquals(
+            'en',
+            $detector->getLanguage()
+        );
+    }
 }


### PR DESCRIPTION
This adds an optional parameter to limit the language models loaded by the detector:

```php
$detector = new LanguageDetector(null, ['da', 'no', 'sv']);
```

Useful when speed and memory usage is a concern. 